### PR TITLE
Add afterrender hook

### DIFF
--- a/src/backbone.modal.coffee
+++ b/src/backbone.modal.coffee
@@ -37,6 +37,7 @@ class Backbone.Modal extends Backbone.View
     @$el.fadeIn
       duration: 100
       complete: =>
+        @afterRender?()
         @modalEl.css(opacity: 1).addClass("#{@prefix}-modal--open")
 
     return this


### PR DESCRIPTION
It's nice to be able to run some code after render has taken place, i.e. code that needs the rendered dom available etc.
