### PR TITLE
Allow HTML5 validation to occur

### DIFF
--- a/src/backbone.modal.coffee
+++ b/src/backbone.modal.coffee
@@ -189,11 +189,13 @@ class Backbone.Modal extends Backbone.View
 
   triggerSubmit: (e) =>
     return unless e
+
+    # To use HTML5 Validation we need to do this without preventDefault.
+     if @beforeSubmit
+      return if @beforeSubmit(e) is false
+
     # triggers submit
     e?.preventDefault()
-
-    if @beforeSubmit
-      return if @beforeSubmit() is false
 
     @submit?()
 


### PR DESCRIPTION
Pushed the beforeSubmit to fire and return before preventDefault.  This would allow a user to call this.$('#theForm').checkValidity(); which causes it's own preventDefault.  Due to browser support and there not always being a form, I didn't want to push checkValidity into the modal.

http://dev.w3.org/html5/spec-preview/constraints.html#the-constraint-validation-api

This was a fix I added to a personal project using this modal.