### PR TITLE
package.json: Update `main` to ref unbundled source

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "title": "Backbone.Modal",
   "name": "backbone.modal",
   "version": "1.1.5",
-  "main": "backbone.modal-bundled.js",
+  "main": "backbone.modal.js",
   "ignore": [
     "test/",
     "examples/"


### PR DESCRIPTION
Given that `main` is probably only relevant to projects that are being
built with browserify/webpack/systemjs, and in these environments,
Marionette is likely being managed individually as a dependency, it
makes sense for Backbone.Modal to specify the unbundled version as
`main`. This way, such projects can import with:

``` js
require('backbone.modal');
```

rather than:

``` js
require('backbone.modal/backbone.modal');
```
