### PR TITLE
package.json: Remove `engines` to prevent warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,6 @@
     "test": "grunt test"
   },
   "bugs": "https://github.com/awkward/backbone.modal/issues",
-  "engines": {
-    "node": "0.8.x",
-    "npm": "1.1.x"
-  },
   "devDependencies": {
     "grunt": "~0.4.5",
     "grunt-contrib-coffee": "~0.12.0",


### PR DESCRIPTION
Prevent npm from showing warning messages on systems that are not
running node 0.8.x (most at this point). `engines` isn't relevant for
browser packages.
