### PR TITLE
Fix re-render behavior

### DIFF
--- a/src/backbone.modal.coffee
+++ b/src/backbone.modal.coffee
@@ -42,6 +42,8 @@
       @openAt(options) if @views?.length > 0 and @showViewOnRender
       @onRender?()
 
+      return true if @active
+
       @delegateModalEvents()
 
       # show modal

--- a/test/src/backbone.modal.spec.coffee
+++ b/test/src/backbone.modal.spec.coffee
@@ -81,9 +81,19 @@ describe 'Backbone.Modal', ->
       expect(view.currentIndex).toBe(2)
 
   describe '#render', ->
+    view = null
+
     it 'renders the modal and internal views', ->
       view = new modal()
       expect((view.render().el instanceof HTMLElement)).toBeTruthy()
+
+    describe 'when called again', ->
+      it 're-renders without animation or event delegation', ->
+        spyOn(view, 'delegateModalEvents')
+        spyOn(view, 'rendererCompleted')
+        view.render()
+        expect(view.delegateModalEvents).not.toHaveBeenCalled()
+        expect(view.rendererCompleted).not.toHaveBeenCalled()
 
   describe '#beforeCancel', ->
     it "should call this method when it's defined", ->


### PR DESCRIPTION
If a given modal is already active and `render` is called again, don't
include the animation.

In addition, by returning early before calling `delegateModalEvents`
again, this should fix a potential memory leak where the previously
attached event handlers weren't being removed before attaching the new
ones.
