### PR TITLE
Save/restore previously focused element

### DIFF
--- a/src/backbone.modal.coffee
+++ b/src/backbone.modal.coffee
@@ -36,8 +36,10 @@
       else
         @viewContainerEl = @modalEl
 
+      $focusEl = Backbone.$(document.activeElement)
+      @previousFocus = $focusEl unless @previousFocus
       # blur links to prevent double keystroke events
-      Backbone.$(':focus').blur()
+      $focusEl.blur()
 
       @openAt(options) if @views?.length > 0 and @showViewOnRender
       @onRender?()
@@ -277,6 +279,7 @@
       removeViews = =>
         @currentView?.remove?()
         @remove()
+        @previousFocus?.focus?()
 
       if @$el.fadeOut and @animate
         @$el.fadeOut(duration: 200)

--- a/test/src/backbone.modal.spec.coffee
+++ b/test/src/backbone.modal.spec.coffee
@@ -56,6 +56,20 @@ describe 'Backbone.Modal', ->
     it "#length should return the length of the total views", ->
       expect(view.views.length).toEqual(3)
 
+  describe '#destroy', ->
+    it 'should restore focus to previously focused element', ->
+      $prevFocus = Backbone.$('<button id="prev-focus">')
+      Backbone.$('body').append($prevFocus)
+      Backbone.$('#prev-focus').focus()
+
+      view = new modal()
+      view.animate = false
+      view.render()
+      view.destroy()
+
+      expect(document.activeElement.id).toEqual('prev-focus')
+      Backbone.$('#prev-focus').remove()
+
   describe '#openAt', ->
     it 'opens a view at the specified index', ->
       view = new modal()
@@ -84,6 +98,12 @@ describe 'Backbone.Modal', ->
     it 'renders the modal and internal views', ->
       view = new modal()
       expect((view.render().el instanceof HTMLElement)).toBeTruthy()
+
+    it 'should save a reference to the previously focused element', ->
+      expected = Backbone.$(document.activeElement)
+      view = new modal()
+      view.render()
+      expect(view.previousFocus).toEqual(expected)
 
   describe '#beforeCancel', ->
     it "should call this method when it's defined", ->


### PR DESCRIPTION
Accessibility enhancement: upon rendering a modal, save a reference to
the previously focused element, and restore focus to that element when
the modal is destroyed.
