### PR TITLE
Auto-focus on render

### DIFF
--- a/src/backbone.modal.coffee
+++ b/src/backbone.modal.coffee
@@ -7,6 +7,20 @@
     factory(_, Backbone, {})
 ) (_, Backbone, Modal) ->
 
+  focusableElements = [
+    'a[href]'
+    'area[href]'
+    'input:not([disabled])'
+    'select:not([disabled])'
+    'textarea:not([disabled])'
+    'button:not([disabled])'
+    'iframe'
+    'object'
+    'embed'
+    '*[tabindex]'
+    '*[contenteditable]'
+  ].join(', ')
+
   class Modal extends Backbone.View
     prefix: 'bbm'
     animate: true
@@ -63,8 +77,15 @@
         @$el.on('click.bbm', @clickOutside)
 
       @modalEl.css(opacity: 1).addClass("#{@prefix}-modal--open")
+      @setInitialFocus()
       @onShow?()
       @currentView?.onShow?()
+
+    setInitialFocus: ->
+      if @autofocus
+        @$(@autofocus).focus()
+      else
+        @$('*').filter(focusableElements).filter(':visible').first().focus()
 
     setUIElements: ->
       # get modal options

--- a/test/src/backbone.modal.spec.coffee
+++ b/test/src/backbone.modal.spec.coffee
@@ -8,7 +8,7 @@ describe 'Backbone.Modal', ->
       viewContainer: 'div'
       cancelEl: '.destroy'
       submitEl: '.submit'
-      template: -> '<a class="class"></a><a id="id"></a><div></div><a data-event="true"></a><a class="destroy"></a><a class="submit"></a>'
+      template: -> '<a href="#" class="class">link</a><a href="#" id="id"></a><div></div><a data-event="true"></a><a class="destroy"></a><a class="submit"></a>'
       views:
         'click .class':
           view: new backboneView
@@ -84,6 +84,29 @@ describe 'Backbone.Modal', ->
     it 'renders the modal and internal views', ->
       view = new modal()
       expect((view.render().el instanceof HTMLElement)).toBeTruthy()
+    it 'should set initial focus', ->
+      view = new modal()
+      spyOn(view, 'setInitialFocus')
+      view.animate = false
+      view.render()
+      expect(view.setInitialFocus).toHaveBeenCalled()
+
+  describe '#setInitialFocus', ->
+    it 'should set focus to first focusable element', ->
+      view = new modal()
+      view.animate = false
+      Backbone.$('body').append(view.render().el)
+      view.setInitialFocus()
+      expect(document.activeElement).toBe(document.querySelector('.class'))
+      view.destroy()
+    it 'should be overridable with autofocus option', ->
+      view = new modal()
+      view.autofocus = '#id'
+      view.animate = false
+      Backbone.$('body').append(view.render().el)
+      view.setInitialFocus()
+      expect(document.activeElement).toBe(document.querySelector('#id'))
+      view.destroy()
 
   describe '#beforeCancel', ->
     it "should call this method when it's defined", ->


### PR DESCRIPTION
Accessibility enhancement: auto-focus the first focusable element within
the modal just prior to `onShow`. The element that is focused can be
specified by setting `autofocus` to a selector or jQuery element.
